### PR TITLE
Increased name & password size to 256

### DIFF
--- a/plugins/GmailNotifier/src/stdafx.h
+++ b/plugins/GmailNotifier/src/stdafx.h
@@ -41,8 +41,8 @@ typedef struct s_resultLink{
 }resultLink;
 
 typedef struct s_Account{
-	char name[64];
-	char pass[64];
+	char name[256];
+	char pass[256];
 	char hosted[64];
 	MCONTACT hContact;
 	int oldResults_num;


### PR DESCRIPTION
Current gmail limits are **30** for name (`char[64]` is ok) and **100** for password (`char[64]` is not ok)
I've increased both to 256 just in case.